### PR TITLE
Link Giyun Choi to personal homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             <!-- Authors -->
             <div class="is-size-5 publication-authors">
               <span class="author-block"><a href="https://chojinie.github.io/" target="_blank">Hyunjin Cho</a><sup>1,3</sup><sup>*</sup>,</span>
-              <span class="author-block"><a href="https://example.com/giyun" target="_blank">Giyun Choi</a><sup>1</sup><sup>*</sup>,</span>
+              <span class="author-block"><a href="https://hdstcc.github.io/" target="_blank">Giyun Choi</a><sup>1</sup><sup>*</sup>,</span>
               <span class="author-block"><a href="https://www.vilab.cau.ac.kr/" target="_blank">Jongwon Choi</a><sup>1,2</sup><sup>†</sup></span>
             </div>
             <div class="is-size-6 publication-authors">


### PR DESCRIPTION
Replaces the placeholder author link (https://example.com/giyun) with Giyun Choi's personal homepage: https://hdstcc.github.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)